### PR TITLE
Support weighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ You may define extended attributes in service descriptor:
         tag="http",
         near="_agent",
         dc="dc2",
-        ["node-meta"]="key:value"
+        ["node-meta"]="key:value",
+        token="consul-token"
       }
     })
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,14 @@
 
 [![Build Status](https://travis-ci.org/xytis/lua-consul-balancer.svg?branch=master)](https://travis-ci.org/xytis/lua-consul-balancer)
 
-Consul enabled upstream balancer. Does exactly what is advertised -- enables nginx to use consul service discovery to forward requests to dynamic upstreams.
+Consul enabled upstream balancer. Does exactly what is advertised -- enables nginx to use consul service discovery to forward requests to dynamic upstreams, and upstream servers support weighting.
 
 ## Usage
 
 Each nginx worker must initialize the library:
 
-    lua_shared_dict consul_balancer 4m;
-
     init_worker_by_lua_block {
       local consul_balancer = require "n4l.consul_balancer"
-      consul_balancer.set_shared_dict_name("consul_balancer") # name of shared dictionary to keep cache in
       consul_balancer.watch("http://127.0.0.1:8500", {"foo", "bar"})
     }
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Consul enabled upstream balancer. Does exactly what is advertised -- enables ngi
 
 Each nginx worker must initialize the library:
 
-    lua_package_path '/lua-consul-balancer/lib/?.lua;/path/to/lua-resty-http/lib/?.lua;/path/tolua-resty-balancer/lib/?.lua;;';
+    lua_package_path '/path/to/lua-consul-balancer/lib/?.lua;/path/to/lua-resty-http/lib/?.lua;/path/to/lua-resty-balancer/lib/?.lua;;';
     lua_package_cpath '/path/to/lua-resty-balancer/?.so;;';
 
     init_worker_by_lua_block {

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 [![Build Status](https://travis-ci.org/xytis/lua-consul-balancer.svg?branch=master)](https://travis-ci.org/xytis/lua-consul-balancer)
 
-Consul enabled upstream balancer. Does exactly what is advertised -- enables nginx to use consul service discovery to forward requests to dynamic upstreams, and upstream servers support weighting.
+Consul enabled upstream balancer. Does exactly what is advertised -- enables nginx to use consul service discovery to forward requests to dynamic upstreams, and upstream servers support weighting(consul version must >= 1.2.3).
 
 ## Usage
 
 Each nginx worker must initialize the library:
+
+    lua_package_path '/lua-consul-balancer/lib/?.lua;/path/to/lua-resty-http/lib/?.lua;/path/tolua-resty-balancer/lib/?.lua;;';
+    lua_package_cpath '/path/to/lua-resty-balancer/?.so;;';
 
     init_worker_by_lua_block {
       local consul_balancer = require "n4l.consul_balancer"

--- a/lib/n4l/consul_balancer.lua
+++ b/lib/n4l/consul_balancer.lua
@@ -107,6 +107,9 @@ local function _build_service_uri(service_descriptor, service_index)
   if service_descriptor["node-meta"] ~= nil then
     args["node-meta"] = service_descriptor["node-meta"]
   end
+  if service_descriptor.token ~= nil then
+    args.token = service_descriptor.token
+  end
   return uri .. "?" .. ngx.encode_args(args)
 end
 

--- a/t/test_shared.t
+++ b/t/test_shared.t
@@ -12,7 +12,7 @@ our $HttpConfig = qq{
     lua_package_path "$pwd/lib/?.lua;/usr/local/lib/lua/?.lua;;";
     error_log logs/error.log debug;
 
-    lua_shared_dict consul_balancer 16k;
+    #lua_shared_dict consul_balancer 16k;
 
     init_by_lua_block {
         if $ENV{TEST_COVERAGE} == 1 then
@@ -23,7 +23,7 @@ our $HttpConfig = qq{
 
     init_worker_by_lua_block {
         local consul_balancer = require "n4l.consul_balancer"
-        consul_balancer.set_shared_dict_name("consul_balancer")
+        --consul_balancer.set_shared_dict_name("consul_balancer")
         consul_balancer.watch("http://127.0.0.1:8500", {
             "foo",
             { name = "bar", service = "bar" },


### PR DESCRIPTION
- Use table instead of shared memory to store "service" objects to support weights.
- Use `while not ngx.worker.exiting() do` instead of `while true do` to fix the problem that "nginx worker: process is shutting down" process of nginx cannot shutdown when reload nginx.